### PR TITLE
Add section for showing multiple metrics in Pivot Table (fixes getred…

### DIFF
--- a/src/pages/kb/user-guide/visualizations/pivot-table-visualizations.md
+++ b/src/pages/kb/user-guide/visualizations/pivot-table-visualizations.md
@@ -31,6 +31,32 @@ Here are some examples using the grade data above:
 
 ![](/assets/images/docs/gitbook/pivot-table-configuration-examples.png)
 
+The Pivot Table visualization can display more than one metric side-by-side under each column group. To do this, your query results must be in **long (melted) format**, with one column for the metric name and one for the metric value.
+
+**Example Query Output Format:**
+
+| Student   | grade | School      | Gender |
+|-----------|-------|-------------|--------|
+| Adams     | 66.54 | Adams       | Female |
+| Adams     | 57.42 | Adams       | Male   |
+| Jefferson | 58.66 | Jefferson   | Female |
+| Jefferson | 66.21 | Jefferson   | Male   |
+| Lincoln   | 64.69 | Lincoln     | Female |
+| Lincoln   | 60.48 | Lincoln     | Male   |
+| McKinley  | 61.39 | McKinley    | Female |
+| McKinley  | 64.85 | McKinley    | Male   |
+| Washington| 64.79 | Washington  | Female |
+| Washington| 62.77 | Washington  | Male   |
+
+You can prepare your data like this in your query (or upstream in your data source).
+
+**To configure the Pivot Table:**
+1. Drag your **row grouping field** (e.g., `School`) into the **Rows** area.  
+2. Drag **Gender** into the **Columns** area.  
+3. Drag **grade** into the **Values** area, and choose the aggregation you want (e.g., *Average*, *Count*, etc.).  
+4. *(Optional)* Add another field to **Rows** or **Columns** to create nested groupings, such as adding `Student` under `School` in the Rows area.  
+
+The result will show each school with separate columns for each gender, plus totals.
 {% callout warning %}
 
 Pivot table performance can degrade if your query result is too big. The exact size threshold will depend on the computer and browser from which you access Redash. But in general, performance is best below 50,000 _fields_. That could mean 10,000 records with 5 fields each. Or 1,000 records with 50 fields each.


### PR DESCRIPTION
…ash#7230)

Added a new paragraph in the section, “Step 2: Add a Pivot Table visualization,” of the user guide page at  https://github.com/getredash/website/blob/master/src/pages/kb/user-guide/visualizations/pivot-table-visualizations.md 
The updated segment clarifies that creating a Pivot Table that displays multiple metrics requires using long (melted) data format, with one column for the metric name and one for the metric value.